### PR TITLE
Fix typo in documentation

### DIFF
--- a/assets/styl/_@blocks/_block.styl
+++ b/assets/styl/_@blocks/_block.styl
@@ -4,7 +4,7 @@
 
 // {clearfix}
 //
-// Adds a clearfix bahavior on containers that have floating children.
+// Adds a clearfix behavior on containers that have floating children.
 //
 // **Usage**
 // ```

--- a/assets/styl/_@blocks/_loading.styl
+++ b/assets/styl/_@blocks/_loading.styl
@@ -1,8 +1,8 @@
 // {loading}
 //
-// display an animated svg loader
+// Display an animated svg loader
 //
-// Advice: use it in a pseudo element (`:before` or `:after)
+// Advice: use it in a pseudo element (`:before` or `:after`)
 //
 // **Usage**
 // ```stylus

--- a/assets/styl/_base/_form-elements.styl
+++ b/assets/styl/_base/_form-elements.styl
@@ -1,6 +1,6 @@
 // Forms
 //
-// Colette comes with basic css to style forms.
+// Colette comes with basic CSS to style forms.
 //
 // Styleguide: Components.Forms
 

--- a/assets/styl/_base/readme.md
+++ b/assets/styl/_base/readme.md
@@ -1,3 +1,3 @@
 Base styles:
-- address html <tags> only
+- address HTML <tags> only
 - no classes nor ids

--- a/assets/styl/_layout/_grid.styl
+++ b/assets/styl/_layout/_grid.styl
@@ -28,7 +28,7 @@
 //          <td align="center">.col-lg-[n]</td>
 //      </tr>
 //      <tr>
-//          <td>Css declaration</td>
+//          <td>CSS declaration</td>
 //          <td colspan="3" align="center">{ width: ([n] / 12) * 100 }</td>
 //      </tr>
 //  </tbody>

--- a/assets/styl/_mixins/_contrast.styl
+++ b/assets/styl/_mixins/_contrast.styl
@@ -51,7 +51,7 @@ _contrast_findFirstMatch($color, $list, $min = $contrast, $index = 0)
 //     border-bottom 1px solid _contrast_choose(#000, #888 #aaa #ddd #fff, $contrast-high)
 // ```
 //
-// Will render this css
+// Will render this CSS
 // ```css
 // .foo {
 //     background: #000;

--- a/assets/styl/_settings.styl
+++ b/assets/styl/_settings.styl
@@ -31,7 +31,7 @@
 //
 // will compile to
 // ```
-// /* css file */
+// /* CSS file */
 // @media screen and (min-width: 960px)
 //     /* styles */
 // ```

--- a/assets/styl/colette.styl
+++ b/assets/styl/colette.styl
@@ -15,7 +15,7 @@
 // @blocks
 //
 // [Stylus @block](http://stylus-lang.com/docs/block.html) let you assign any block of code to a variable and then call it, pass as an argument or reuse in any other way.
-// Colette takes avantage of this feature to define common and reusable pieces of css code.
+// Colette takes avantage of this feature to define common and reusable pieces of CSS code.
 //
 // Weight: 13
 //

--- a/docs/index.html
+++ b/docs/index.html
@@ -129,7 +129,7 @@
             </div>
             <section id="kssref-homepage" class="co_section-home co_section-depth-2 co_content pl2 pr2">
                 <h1 id="introducing-colette">Introducing Colette</h1>
-<p>Colette is a css and js starter kit for 20 Minutes web projects.
+<p>Colette is a CSS and JS starter kit for 20 Minutes web projects.
 It provides basic styles and mixins to build responsive layouts,
 based on the 20 Minutes digital identity guidelines.</p>
 <hr>
@@ -138,7 +138,7 @@ based on the 20 Minutes digital identity guidelines.</p>
 <li>basic typography: headings, body text, lists, etc.</li>
 <li>helpers: colors, borders, icons, etc.</li>
 <li>grid system: 12-columns based, with customizable breakpoints</li>
-<li>ready-to-use html/css components: buttons, navbar, socialbar,
+<li>ready-to-use HTML/CSS components: buttons, navbar, socialbar,
 content teasers, media, and loading animation</li>
 </ul>
 <hr>
@@ -160,7 +160,7 @@ that allows you to react to the user&#39;s scroll.</li>
 <h2 id="download">Download</h2>
 <ul>
 <li>See the <a href="https://github.com/20minutes/colette/dist/"><code>dist/</code></a>
-directory for ready-to-use css files.</li>
+directory for ready-to-use CSS files.</li>
 <li>If you want to use Colette as a kickstarter for custom stylus/css
 projects, check <a href="https://github.com/20minutes/colette/assets/"><code>src/</code></a>.</li>
 </ul>
@@ -185,8 +185,8 @@ gulp.task(&#39;css&#39;, function () {
 </code></pre>
 <p><code>PATH_TO_STYLUS_IMPORT</code> could be <code>node_modules</code> for example if you use npm.</p>
 <h3 id="partial-import">Partial import</h3>
-<p>Colette is a collection of stylus features. You can define which styles you want to include into your final css file with stylus import.</p>
-<p>By default, you include all <code>colette.styl</code> and all features are in your css.
+<p>Colette is a collection of stylus features. You can define which styles you want to include into your final CSS file with stylus import.</p>
+<p>By default, you include all <code>colette.styl</code> and all features are in your CSS.
 You can select features needed by copying <code>colette.styl</code> content and choose your imports rules.</p>
 <pre><code>/* my_css_file.styl */
 
@@ -200,10 +200,10 @@ You can select features needed by copying <code>colette.styl</code> content and 
 <ul>
 <li>change order of imports,</li>
 <li>import only needed features,</li>
-<li>separate your critical css from your global css.</li>
+<li>separate your critical CSS from your global CSS.</li>
 </ul>
-<h4 id="usage-example-handle-critical-css">Usage example: Handle critical css</h4>
-<p>You need to create a specific stylus file to handle your critical css.</p>
+<h4 id="usage-example-handle-critical-css">Usage example: Handle critical CSS</h4>
+<p>You need to create a specific stylus file to handle your critical CSS.</p>
 <pre><code>/* my_criticalcss_file.styl */
 
 // Your own settings
@@ -243,7 +243,7 @@ You can select features needed by copying <code>colette.styl</code> content and 
 @require &#39;colette/assets/styl/_helpers/_spaces&#39;
 
 /* =&gt; will compile to my_criticalcss_file.css */
-</code></pre><p>and then simply include the compiled css file into your template
+</code></pre><p>and then simply include the compiled CSS file into your template
 (do not forget the <code>&lt;style&gt;</code> tag around your <code>include</code>!):</p>
 <pre><code class="lang-twig">&lt;style&gt;
    {% include &#39;css/my_criticalcss_file.css&#39; %}

--- a/docs/item--blocks-block-clearfix.html
+++ b/docs/item--blocks-block-clearfix.html
@@ -146,7 +146,7 @@
                             <div class="co_subsection clearfix">
                     <p class="co_subsection-title col-md-3">Description</p>
                     <div class="co_subsection-content col-md-9">
-                        <p>Adds a clearfix bahavior on containers that have floating children.</p>
+                        <p>Adds a clearfix behavior on containers that have floating children.</p>
 <p><strong>Usage</strong></p>
 <pre><code>/* my_file.styl */
 .foo

--- a/docs/item--blocks-block-loading.html
+++ b/docs/item--blocks-block-loading.html
@@ -146,8 +146,8 @@
                             <div class="co_subsection clearfix">
                     <p class="co_subsection-title col-md-3">Description</p>
                     <div class="co_subsection-content col-md-9">
-                        <p>display an animated svg loader</p>
-<p>Advice: use it in a pseudo element (<code>:before</code> or `:after)</p>
+                        <p>Display an animated svg loader</p>
+<p>Advice: use it in a pseudo element (<code>:before</code> or <code>:after</code>)</p>
 <p><strong>Usage</strong></p>
 <pre><code class="lang-stylus">/* my_file.styl */
 .foo

--- a/docs/item--blocks.html
+++ b/docs/item--blocks.html
@@ -145,7 +145,7 @@
                     <p class="co_subsection-title col-md-3">Description</p>
                     <div class="co_subsection-content col-md-9">
                         <p><a href="http://stylus-lang.com/docs/block.html">Stylus @block</a> let you assign any block of code to a variable and then call it, pass as an argument or reuse in any other way.
-Colette takes avantage of this feature to define common and reusable pieces of css code.</p>
+Colette takes avantage of this feature to define common and reusable pieces of CSS code.</p>
 
                     </div>
                 </div>

--- a/docs/item-components-forms.html
+++ b/docs/item-components-forms.html
@@ -146,7 +146,7 @@
                             <div class="co_subsection clearfix">
                     <p class="co_subsection-title col-md-3">Description</p>
                     <div class="co_subsection-content col-md-9">
-                        <p>Colette comes with basic css to style forms.</p>
+                        <p>Colette comes with basic CSS to style forms.</p>
 
                     </div>
                 </div>

--- a/docs/item-layout-grid.html
+++ b/docs/item-layout-grid.html
@@ -175,7 +175,7 @@ Grid classes are set according to:</p>
          <td align="center">.col-lg-[n]</td>
      </tr>
      <tr>
-         <td>Css declaration</td>
+         <td>CSS declaration</td>
          <td colspan="3" align="center">{ width: ([n] / 12) * 100 }</td>
      </tr>
  </tbody>

--- a/docs/item-mixins-contrast-choose.html
+++ b/docs/item-mixins-contrast-choose.html
@@ -154,7 +154,7 @@
     color _contrast_choose(#000, #888 #aaa #ddd #fff)
     border-bottom 1px solid _contrast_choose(#000, #888 #aaa #ddd #fff, $contrast-high)
 </code></pre>
-<p>Will render this css</p>
+<p>Will render this CSS</p>
 <pre><code class="lang-css">.foo {
     background: #000;
     color: #888;

--- a/docs/item-settings-grid.html
+++ b/docs/item-settings-grid.html
@@ -165,7 +165,7 @@
 @media $breakpoints.lg
     /* styles */
 </code></pre><p>will compile to</p>
-<pre><code>/* css file */
+<pre><code>/* CSS file */
 @media screen and (min-width: 960px)
     /* styles */
 </code></pre>

--- a/docs/section--blocks.html
+++ b/docs/section--blocks.html
@@ -145,7 +145,7 @@
                     <p class="co_subsection-title col-md-3">Description</p>
                     <div class="co_subsection-content col-md-9">
                         <p><a href="http://stylus-lang.com/docs/block.html">Stylus @block</a> let you assign any block of code to a variable and then call it, pass as an argument or reuse in any other way.
-Colette takes avantage of this feature to define common and reusable pieces of css code.</p>
+Colette takes avantage of this feature to define common and reusable pieces of CSS code.</p>
 
                     </div>
                 </div>
@@ -214,7 +214,7 @@ Colette takes avantage of this feature to define common and reusable pieces of c
                             <div class="co_subsection clearfix">
                     <p class="co_subsection-title col-md-3">Description</p>
                     <div class="co_subsection-content col-md-9">
-                        <p>Adds a clearfix bahavior on containers that have floating children.</p>
+                        <p>Adds a clearfix behavior on containers that have floating children.</p>
 <p><strong>Usage</strong></p>
 <pre><code>/* my_file.styl */
 .foo
@@ -364,8 +364,8 @@ If applied to a <code>&lt;ul&gt;</code> or <code>&lt;ol&gt;</code> tag, all its 
                             <div class="co_subsection clearfix">
                     <p class="co_subsection-title col-md-3">Description</p>
                     <div class="co_subsection-content col-md-9">
-                        <p>display an animated svg loader</p>
-<p>Advice: use it in a pseudo element (<code>:before</code> or `:after)</p>
+                        <p>Display an animated svg loader</p>
+<p>Advice: use it in a pseudo element (<code>:before</code> or <code>:after</code>)</p>
 <p><strong>Usage</strong></p>
 <pre><code class="lang-stylus">/* my_file.styl */
 .foo

--- a/docs/section-components.html
+++ b/docs/section-components.html
@@ -1745,7 +1745,7 @@ All social colors are available to style the button according to its context.</p
                             <div class="co_subsection clearfix">
                     <p class="co_subsection-title col-md-3">Description</p>
                     <div class="co_subsection-content col-md-9">
-                        <p>Colette comes with basic css to style forms.</p>
+                        <p>Colette comes with basic CSS to style forms.</p>
 
                     </div>
                 </div>

--- a/docs/section-layout.html
+++ b/docs/section-layout.html
@@ -272,7 +272,7 @@ Grid classes are set according to:</p>
          <td align="center">.col-lg-[n]</td>
      </tr>
      <tr>
-         <td>Css declaration</td>
+         <td>CSS declaration</td>
          <td colspan="3" align="center">{ width: ([n] / 12) * 100 }</td>
      </tr>
  </tbody>

--- a/docs/section-mixins.html
+++ b/docs/section-mixins.html
@@ -224,7 +224,7 @@
     color _contrast_choose(#000, #888 #aaa #ddd #fff)
     border-bottom 1px solid _contrast_choose(#000, #888 #aaa #ddd #fff, $contrast-high)
 </code></pre>
-<p>Will render this css</p>
+<p>Will render this CSS</p>
 <pre><code class="lang-css">.foo {
     background: #000;
     color: #888;

--- a/docs/section-settings.html
+++ b/docs/section-settings.html
@@ -194,7 +194,7 @@
 @media $breakpoints.lg
     /* styles */
 </code></pre><p>will compile to</p>
-<pre><code>/* css file */
+<pre><code>/* CSS file */
 @media screen and (min-width: 960px)
     /* styles */
 </code></pre>

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Introducing Colette
-Colette is a css and js starter kit for 20 Minutes web projects.
+Colette is a CSS and JS starter kit for 20 Minutes web projects.
 It provides basic styles and mixins to build responsive layouts,
 based on the 20 Minutes digital identity guidelines.
 
@@ -8,7 +8,7 @@ based on the 20 Minutes digital identity guidelines.
 - basic typography: headings, body text, lists, etc.
 - helpers: colors, borders, icons, etc.
 - grid system: 12-columns based, with customizable breakpoints
-- ready-to-use html/css components: buttons, navbar, socialbar,
+- ready-to-use HTML/CSS components: buttons, navbar, socialbar,
 content teasers, media, and loading animation
 
 ---
@@ -34,7 +34,7 @@ npm install colette --save
 ---
 ## Download
 - See the [`dist/`](https://github.com/20minutes/colette/dist/)
-directory for ready-to-use css files.
+directory for ready-to-use CSS files.
 - If you want to use Colette as a kickstarter for custom stylus/css
 projects, check [`src/`](https://github.com/20minutes/colette/assets/).
 
@@ -69,9 +69,9 @@ gulp.task('css', function () {
 
 ### Partial import
 
-Colette is a collection of stylus features. You can define which styles you want to include into your final css file with stylus import.
+Colette is a collection of stylus features. You can define which styles you want to include into your final CSS file with stylus import.
 
-By default, you include all `colette.styl` and all features are in your css.
+By default, you include all `colette.styl` and all features are in your CSS.
 You can select features needed by copying `colette.styl` content and choose your imports rules.
 
 ```
@@ -88,11 +88,11 @@ You can select features needed by copying `colette.styl` content and choose your
 But can be usefull to:
 * change order of imports,
 * import only needed features,
-* separate your critical css from your global css.
+* separate your critical CSS from your global CSS.
 
-#### Usage example: Handle critical css
+#### Usage example: Handle critical CSS
 
-You need to create a specific stylus file to handle your critical css.
+You need to create a specific stylus file to handle your critical CSS.
 
 ```
 /* my_criticalcss_file.styl */
@@ -136,7 +136,7 @@ You need to create a specific stylus file to handle your critical css.
 /* => will compile to my_criticalcss_file.css */
 ```
 
-and then simply include the compiled css file into your template
+and then simply include the compiled CSS file into your template
 (do not forget the `<style>` tag around your `include`!):
 
 ```twig


### PR DESCRIPTION
- Use caps for CSS, JS and HTML
- Misc typo