### PR TITLE
Fix: Update build to fix postinstall error when using colette as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ cache:
   directories:
     - "node_modules"
 
+script:
+  - gulp build
+  - gulp docs
+
 deploy:
   provider: pages
   skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "favicon.ico"
   ],
   "scripts": {
-    "postinstall": "gulp build && gulp docs",
     "test": "gulp test"
   },
   "repository": {


### PR DESCRIPTION
When using Colette as a dependency, we get an error on the `postinstall` script that build the dist/ and doc files.
This PR removes the gulp `build` and `docs` tasks, and let travis run them instead. 