### PR TITLE
Fixed logo problem on Firefox

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "colette",
-    "version": "0.28.3",
+    "version": "0.28.4",
     "license": "MIT",
     "ignore": [
         "**/.*",

--- a/kss-builder/styl/co-styles.styl
+++ b/kss-builder/styl/co-styles.styl
@@ -164,12 +164,10 @@ $co-color-body = #f1f1f1
 
             svg
                 position absolute
-                left 12rem /* sidebar width/2 */
+                left calc(24rem/2 - 6rem/2) /* sidebar width / 2 - logo width / 2 AVOID % here, otherwise it will cause the logo to blink when the scrollbar appears */
                 width 6rem
                 height @width
                 fill $co-color-primary
-                transform translateX(-50%)
-                /* a bit heavy to center the logo, but this prevents from blinking when we get the scroll bar on hover */
 
     /* overlay */
     &_overlay

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "license": "MIT",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
I fixed the problem we had with the logo on Firefox. I was only partly visible because of a 'translate' property in CSS. 
I managed it differently.

<img width="795" alt="capture d ecran 2017-09-29 a 17 11 05" src="https://user-images.githubusercontent.com/25796535/31022480-3774a53c-a539-11e7-8eb4-278cd9cd6863.png">
