### PR TITLE
Prevent extrem low color ratio

### DIFF
--- a/assets/styl/_helpers/_colors.styl
+++ b/assets/styl/_helpers/_colors.styl
@@ -15,4 +15,4 @@ for key, value in $colors
         background-color value
 
     .color-{key}
-        color value
+        color _contrast_choose($color-white, value $color-base, 1.5)


### PR DESCRIPTION
# What did you fix or what feature did you add?

I add a fallback on $color-base if theme color has a realy low constast with white.

Useful for `native` theme color
