### PR TITLE
Select arrow

### DIFF
--- a/assets/styl/_base/_form.styl
+++ b/assets/styl/_base/_form.styl
@@ -107,11 +107,15 @@ input[type='date']
 // Styleguide: Forms.Select
 select
     padding-right 2em
-    background-image url('data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\" fill=\"#000\"><polygon points=\"0, 0 100, 0 50, 50\" /></svg>')
+    background-image svgImport('../../svg/arrow/down.svg' '
+        path
+            fill ' + $color-base + '
+    ') // @stylint ignore
     background-repeat no-repeat
-    background-position calc(100% - .75em) 1em
-    background-size .5em .5em
-    -webkit-appearance none // the svg background arrow doesn't display on FF, so we only target -webkit
+    background-position calc(100% - .6em) .75em
+    background-size .8em .8em
+    -moz-appearance none
+    -webkit-appearance none
 
 // Textarea
 //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",


### PR DESCRIPTION
# What did you fix or what feature did you add?
I fixed the select svg arrow import.
The arrow wasn't visible because of a bad import

## Before 
![image](https://user-images.githubusercontent.com/35305886/58970210-3a666780-87b9-11e9-91d5-a305d05001d3.png)

## After 
![image](https://user-images.githubusercontent.com/35305886/58970153-2589d400-87b9-11e9-93d9-2f6a0f4c83aa.png)

# Related story / issue:
Github issue: #314

