### PR TITLE
Change scroll technique for modals and add size modifiers

### DIFF
--- a/assets/styl/_components/_modal.styl
+++ b/assets/styl/_components/_modal.styl
@@ -2,10 +2,15 @@
 //
 // Colette uses the accessible modal [a11y-dialog](https://www.npmjs.com/package/a11y-dialog).
 //
+// By defaut modal is 90% of viewport width
+//
 // For react project we use [react-modal](https://www.npmjs.com/package/react-modal)
 // but CSS need some overwrite to match the overlay as a wrapper.
 //
-// .modal-window-closeOutside - to let close button outside modal body
+// .modal-window-auto - modal width related to content
+// .modal-window-small - modal width 440px
+// .modal-window-medium - modal width 600px
+// .modal-window-closeOutside - close button outside modal body
 //
 // Markup: modal.twig
 //
@@ -19,20 +24,20 @@
 // Styleguide Components.Modal.demo
 .modal
     position fixed
+    overflow auto
     width 100%
     height 100%
     z-index: $zIndex.modals
     top 0
     left 0
     display flex
-    align-items center
-    justify-content center
+    -webkit-overflow-scrolling touch // enable iOs momentum-based scrolling
 
     &[aria-hidden=true]
         display none
 
     &-overlay
-        position absolute
+        position fixed
         top -30%
         bottom -30% // These negative values avoid gap between address bar & overlay, on mobile, when address bar disappear
         left 0
@@ -40,23 +45,35 @@
         background rgba(0, 0, 0, .6)
 
     &-window
-        -webkit-overflow-scrolling touch // enable iOs momentum-based scrolling
+        _pt(1)
+        _pb(1)
         position relative
+        margin auto
+        width 90%
         max-width 90%
-        max-height 90%
         display flex
         flex-direction column
 
+        &-auto
+            width auto
+
+        &-small
+            width _rem(440)
+
+        &-medium
+            width _rem(600)
+
         &-closeOutside
-            padding-top: _rem(40px)
+            padding-top _rem(40px)
 
             .modal-close
+                top _rem(10px)
                 right 0
 
     &-close
         position absolute
         z-index 2
-        top _rem(10px)
+        top _rem(10px) + _gutters(1)
         right _rem(10px)
 
         svg
@@ -68,6 +85,5 @@
     &-content
         position relative
         z-index 1
-        overflow auto
         width 100%
-        height 100%
+        overflow hidden

--- a/assets/styl/_components/modal.twig
+++ b/assets/styl/_components/modal.twig
@@ -1,6 +1,6 @@
 <!-- For demo, we overide some css of `.modal` properties to not make it overlay all the viewport -->
 <div class="modal" style="height:50vh; max-height:25rem; position:relative; overflow:hidden;" >
-    <div class="modal-overlay" data-a11y-dialog-hide="true"></div>
+    <div class="modal-overlay" style="position:absolute;" data-a11y-dialog-hide="true"></div>
     <div class="modal-window {{modifier_class}}" role="dialog" open="">
         <button type="button" class="modal-close btnIcon" data-a11y-dialog-hide="true"><svg height="12" width="12"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#symbol-cross"></use></svg></button>
         <div class="modal-content box pa3">This is an accessible modal</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",


### PR DESCRIPTION
# What did you fix or what feature did you add?
1. Change scroll technique : scroll modal wrapper instead of modal content
2. Add size modifiers for `.modal-window`

![Capture d’écran 2019-08-02 à 18 38 42](https://user-images.githubusercontent.com/1309340/62385274-e8418880-b554-11e9-9032-7136fc1b0757.png)

