### PR TITLE
Fix button as tab text-transform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",

--- a/src/styl/_components/_tabpanel.styl
+++ b/src/styl/_components/_tabpanel.styl
@@ -49,6 +49,7 @@
             justify-content center
             align-items center
             cursor pointer
+            text-transform inherit // `text-transform: none;` set on button by normalize
             font-size 1em
             line-height 1.5em
             background $color-base-lighten


### PR DESCRIPTION
# What did you fix or what feature did you add?
I fixed tabs ability to be styled by inheritance on `text-transform` property if it's a `<button>`
