### PR TITLE
Feature/at root for var

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0-alpha.3",
+  "version": "5.0.0-alpha.4",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",

--- a/src/styl/_base/_form.styl
+++ b/src/styl/_base/_form.styl
@@ -5,7 +5,7 @@
 // Weight: 3
 //
 // Styleguide: Forms
-:root
+/:root
     --form-input-bg-color: var(--color-bg-primary)
     --form-input-text-color: var(--color-base)
     --form-input-border-color: var(--color-fade)

--- a/src/styl/_base/_init.styl
+++ b/src/styl/_base/_init.styl
@@ -19,7 +19,7 @@ body
     min-height 100%
 
 body
-[data-theme=dark] // allow darkmode only on a block
+/[data-theme=dark] // allow darkmode only on a block
     background-color var(--color-bg-base)
     color var(--color-base)
 

--- a/src/styl/_components/_box.styl
+++ b/src/styl/_components/_box.styl
@@ -9,8 +9,8 @@
 // Markup: box.twig
 //
 // Styleguide: Components.Box
-:root
-[data-theme=light]
+/:root
+/[data-theme=light]
     --box-bg-color var(--color-bg-primary)
     --box-edge-color alpha($color-black, .02)
 

--- a/src/styl/_components/_breakingnews.styl
+++ b/src/styl/_components/_breakingnews.styl
@@ -6,11 +6,11 @@
 // Markup: breakingnews.twig
 //
 // Styleguide: Components.BreakingNews
-:root
-[data-theme=light]
+/:root
+/[data-theme=light]
     --color-breakingnews-title: var(--color-highlight)
 
-[data-theme=dark]
+/[data-theme=dark]
     --color-breakingnews-title: var(--color-highlight-foreground)
 
 .breakingnews

--- a/src/styl/_components/_footerbar.styl
+++ b/src/styl/_components/_footerbar.styl
@@ -12,12 +12,12 @@ $footer-color-foreground ?= lighten(desaturate($color-theme-default, 30%), 65%)
 $footer-color-dark ?= $color-theme-default-dark
 $footer-color-foreground-dark ?= lighten(desaturate($footer-color-dark, 30%), 65%)
 
-:root
-[data-theme=light]
+/:root
+/[data-theme=light]
     --footer-color: $footer-color
     --footer-color-foreground: $footer-color-foreground
 
-[data-theme=dark]
+/[data-theme=dark]
     --footer-color: $footer-color-dark
     --footer-color-foreground: $footer-color-foreground-dark
 

--- a/src/styl/_components/_navbar.styl
+++ b/src/styl/_components/_navbar.styl
@@ -6,11 +6,11 @@
 // Markup: navbar.twig
 //
 // Styleguide: Components.navbar
-:root
-[data-theme=light]
+/:root
+/[data-theme=light]
     --color-navbar-brand: var(--color-theme-default)
 
-[data-theme=dark]
+/[data-theme=dark]
     --color-navbar-brand: $color-white
 
 .navbar

--- a/src/styl/_elements/_alert.styl
+++ b/src/styl/_elements/_alert.styl
@@ -13,7 +13,7 @@
 _alert(color)
     background-color lighten(desaturate(color, 10%), 90%)
     color color
-:root
+/:root
     --alert-color: var(--color-fade)
     --alert-text-color: var(--color-base)
 

--- a/src/styl/_elements/_btn.styl
+++ b/src/styl/_elements/_btn.styl
@@ -7,8 +7,8 @@
 // Markup: btn.twig
 //
 // Styleguide: Elements.Buttons
-:root
-[data-theme=light]
+/:root
+/[data-theme=light]
     --btn-color: var(--color-bg-tertiary)
     --btn-text-color: var(--color-base)
 

--- a/src/styl/_elements/_media.styl
+++ b/src/styl/_elements/_media.styl
@@ -27,11 +27,11 @@
 // Markup: media-empty.twig
 //
 // Styleguide: Elements.Media.Empty
-:root
-[data-theme=light]
+/:root
+/[data-theme=light]
     --color-bg-mediaImage: lighten($color-theme-default, 80%)
 
-[data-theme=dark]
+/[data-theme=dark]
     --color-bg-mediaImage: $color-black
 
 .media

--- a/src/styl/_variables/_color.styl
+++ b/src/styl/_variables/_color.styl
@@ -3,8 +3,8 @@
 // Every design’s colors are declined as CSS custom properties.
 //
 // Styleguide: CSSvariables.color
-:root
-[data-theme=light]
+/:root
+/[data-theme=light]
     --color-primary: $color-foreground-1
     --color-secondary: $color-foreground-2
 
@@ -45,7 +45,7 @@
 
 // Ready to set a dark mode using an attribute
 // to overwrite those colors
-[data-theme=dark]
+/[data-theme=dark]
     --color-primary: $color-foreground-1-dark
     --color-secondary: $color-foreground-2-dark
 

--- a/src/styl/_variables/_light.styl
+++ b/src/styl/_variables/_light.styl
@@ -3,11 +3,11 @@
 // Every design’s colors are declined as CSS custom properties.
 //
 // Styleguide: CSSvariables.light
-:root
-[data-theme=light]
+/:root
+/[data-theme=light]
     --light-min: 0%
     --light-max: 100%
 
-[data-theme=dark]
+/[data-theme=dark]
     --light-min: 100%
     --light-max: 0%


### PR DESCRIPTION
# What did you fix or what feature did you add?
I use `/` stylus root reference selector to make css variable to root level even if this stylus is scoped.
