### PR TITLE
Blocktitle lined border color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3463,9 +3463,9 @@
       "dev": true
     },
     "colette-kss-builder": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/colette-kss-builder/-/colette-kss-builder-5.2.0.tgz",
-      "integrity": "sha512-3hGjBJ6AKrTnkq8PGR/sqXAb++RJVNaLrJJPIDuLlo3UB09KULLTkPJvnAgZZrSt2VT2hra4JczB3g1Cs+YZiQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/colette-kss-builder/-/colette-kss-builder-5.2.1.tgz",
+      "integrity": "sha512-JlxixMRm0ariE81Lv0JV49hD102sCfVvzWIxEB3ktfBarLpkmI4xZonBPLVyuZShl9PPf49mKhz61J5ZZBanrA==",
       "dev": true,
       "requires": {
         "details-element-polyfill": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.6",
     "clean-webpack-plugin": "^3.0.0",
-    "colette-kss-builder": "^5.2.0",
+    "colette-kss-builder": "^5.2.1",
     "copy-webpack-plugin": "^5.0.5",
     "core-js": "^3.4.1",
     "css-loader": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",

--- a/src/styl/_components/_block.styl
+++ b/src/styl/_components/_block.styl
@@ -155,7 +155,7 @@ $block-colors ?= merge($colors-themes, {
 
                 &-lined
                     background-color transparent // overide theme for `.block-title`
-                    border-bottom-color value
+                    border-bottom-color s('var(--color-%s)', unquote(key))
                     text-shadow none
                     color _contrast_choose($color-white, value darken(value, 10%) darken(value, 20%) darken(value, 30%) darken(value, 40%) $color-base)
 


### PR DESCRIPTION
# What did you fix or what feature did you add?
I fixed the color-bottom of the block-title lined.
The original them-color was applied and not the dark one.

I also updated colette-kss-version to have the correct switch colors on the menu

Screenshots before:
![image](https://user-images.githubusercontent.com/35305886/69249505-43ec5c00-0bae-11ea-9971-1ea6ef8d54aa.png)

after:
![image](https://user-images.githubusercontent.com/35305886/69249448-2a4b1480-0bae-11ea-92f6-9782a1405556.png)

![image](https://user-images.githubusercontent.com/35305886/69249597-6ed6b000-0bae-11ea-9082-bef8c1446db3.png)

