### PR TITLE
Fix size and alignment of Pager element in Colette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0-beta.7",
+  "version": "5.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0-beta.7",
+  "version": "5.0.0-beta.8",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",

--- a/src/styl/_elements/_pager.styl
+++ b/src/styl/_elements/_pager.styl
@@ -35,7 +35,6 @@
         background transparent
         color var(--color-base)
         line-height 1em
-        margin-bottom -.1em
         position relative
 
         &:disabled
@@ -43,7 +42,7 @@
             color var(--color-secondary)
 
         svg
-            width 1em
+            width 1.4em
             height @width
 
         // this after pseudo element extend clickable area


### PR DESCRIPTION
# What did you fix or what feature did you add?
After the add of new pictos arrows, I've fixed their size (to they are more visible) and I've fixed their alignment in the Colette's Pager element

### Related story / issue:

Github issue: Github issue: # https://zube.io/20minutes/vega/c/11543

### Before :
![image](https://user-images.githubusercontent.com/19707072/70077856-e7535d00-1601-11ea-9b8a-e3f08125c9f3.png)

### After :
![image](https://user-images.githubusercontent.com/19707072/70077890-fafec380-1601-11ea-887b-73f470130532.png)