### PR TITLE
Fix line height teaser headline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0-beta.11",
+  "version": "5.0.0-beta.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0-beta.11",
+  "version": "5.0.0-beta.12",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",

--- a/src/styl/_elements/_teaser.styl
+++ b/src/styl/_elements/_teaser.styl
@@ -26,6 +26,7 @@
         margin 0
         font-weight bold
         font-size _rem(11px)
+        line-height _getLh(@font-size)
         text-transform uppercase
 
     &-title


### PR DESCRIPTION
# What did you fix or what feature did you add?

I fixed line height teaser headline.

## Before
![Capture d’écran 2020-01-09 à 10 50 23](https://user-images.githubusercontent.com/1309340/72056981-edf28580-32cd-11ea-8342-f309d52cb5ca.png)

## After
![Capture d’écran 2020-01-09 à 10 50 31](https://user-images.githubusercontent.com/1309340/72056983-edf28580-32cd-11ea-9be9-0163ba8100db.png)

