### PR TITLE
Add flex: X to flexbox helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.1-0",
+  "version": "5.0.0-beta.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "v5.0.0-beta.13",
+  "version": "5.0.0-beta.14",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",

--- a/src/styl/_helpers/_block.styl
+++ b/src/styl/_helpers/_block.styl
@@ -68,7 +68,12 @@
 //
 // - **.d-flex**:     display flex of a block or a list
 // - **.d-iFlex**:    display inline-flex of a block or a list
-// -
+//
+// - **.flx0**:      apply flex: 0
+// - **.flx1**:      apply flex: 1
+// - **.flx2**:      apply flex: 2
+// - **.flx3**:      apply flex: 3
+//
 // - **.fd-row**:     apply flex direction in row to the flex-items
 // - **.fd-rowRev**:  apply flex direction in row-reverse to the flex-items
 // - **.fd-col**:     apply flex direction in column to the flex-items
@@ -118,6 +123,10 @@
 
 .d-iFlex
     display inline-flex
+
+for i in (0..3)
+    .flx{i}
+        flex i
 
 .fd-row
     flex-direction row


### PR DESCRIPTION
### What did you fix or what feature did you add?

I have added the properties flex: 0, flex: 1, flex: 2, flex: 3 to the flexbox helper

### Related story / issue:
https://zube.io/20minutes/colette/c/569

![image](https://user-images.githubusercontent.com/19707072/73387813-6519a900-42d1-11ea-93c7-71860a054a22.png)
