### PR TITLE
Avatar border is thinner now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",

--- a/src/styl/_elements/_avatar.styl
+++ b/src/styl/_elements/_avatar.styl
@@ -2,6 +2,9 @@
 //
 // Use a square image.
 //
+// Avatar element use `em` so we can and should modify its font-size
+// to manage the size of the element.
+//
 // Markup: avatar.twig
 //
 // Styleguide: Elements.avatar
@@ -9,11 +12,11 @@
     display inline-block
     vertical-align middle
     overflow hidden
-    width 2.625em // 42px retative to 16px // TODO: use a convert (px to em) function
-    height 2.625em // 42px retative to 16px // TODO: use a convert (px to em) function
+    width _em(42px)
+    height @width
     border-radius 80em // excessive value to keep it round
     background var(--color-borders)
-    border 3px solid var(--color-borders)
+    border 1px solid var(--color-borders)
 
     > img
     > svg


### PR DESCRIPTION
# What did you fix or what feature did you add?
 The border is thinner now.

## Before
![Capture d’écran 2020-03-10 à 10 13 34](https://user-images.githubusercontent.com/1309340/76297246-d75db000-62b7-11ea-9bea-149e9b11b1a4.png)
![Capture d’écran 2020-03-10 à 10 13 15](https://user-images.githubusercontent.com/1309340/76297247-d7f64680-62b7-11ea-813a-c69dc266174b.png)

## After
![Capture d’écran 2020-03-10 à 11 00 57](https://user-images.githubusercontent.com/1309340/76302740-ce251100-62c0-11ea-8d4a-7ffe11890571.png)
![Capture d’écran 2020-03-10 à 11 00 40](https://user-images.githubusercontent.com/1309340/76302743-cebda780-62c0-11ea-9a97-6c3a86662628.png)

