### PR TITLE
Fix height for img in preview-inline

### DIFF
--- a/src/styl/_components/_preview.styl
+++ b/src/styl/_components/_preview.styl
@@ -234,8 +234,8 @@
             flex-basis 30%
 
             img
-                height 100%
                 width auto
+                height @width
 
         .preview
             &-footer


### PR DESCRIPTION
# What did you fix or what feature did you add?

By importing the new styles of Colette,
I found that the style of the height of the image of the preview-inline modifier.

# Related story / issue:
https://zube.io/20minutes/vega/c/13411

# Screenshots :
### Before
![image](https://user-images.githubusercontent.com/19707072/84788588-929c9000-afef-11ea-87be-917271adf38e.png)

### After
![image](https://user-images.githubusercontent.com/19707072/84788528-844e7400-afef-11ea-8488-0687665202ce.png)
