### PR TITLE
Fix height for img in preview-inline with release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",

--- a/src/styl/_components/_preview.styl
+++ b/src/styl/_components/_preview.styl
@@ -235,7 +235,7 @@
 
             img
                 width auto
-                height @width
+                height auto
 
         .preview
             &-footer


### PR DESCRIPTION
# What did you fix or what feature did you add?

By importing the new styles of Colette,
I found that the style of the height of the image of the preview-inline modifier.

# Related story / issue:
https://zube.io/20minutes/vega/c/13411

# Screenshots :
### Before
![image](https://user-images.githubusercontent.com/19707072/84788588-929c9000-afef-11ea-87be-917271adf38e.png)

### After
![image](https://user-images.githubusercontent.com/19707072/84788528-844e7400-afef-11ea-8488-0687665202ce.png)
