### PR TITLE
Update Travis to avoid double build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+dist: xenial
+os: linux
 language: node_js
 
-cache:
-  directories:
-    - "node_modules"
+# avoid double Travis build when the PR is created on upstream
+if: |
+    type = pull_request OR \
+    branch = master
 
 script:
   - npm run build
@@ -18,9 +21,10 @@ jobs:
       script: npm run docs
       node_js: "12"
       deploy:
+        strategy: git
         provider: pages
-        skip_cleanup: true
-        github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+        cleanup: true
+        token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
         local_dir: dist
         on:
           branch: master
@@ -30,9 +34,9 @@ jobs:
       node_js: "12"
       deploy:
         provider: npm
-        skip_cleanup: true
+        cleanup: true
         email: "web-tech+npm@20minutes.fr"
-        api_key:
+        api_token:
           # This is the NPM token finishing by e8f7
           secure: "AuyoDlLWUnaOAeXJHeawfteCHyKj3imdNel+Lha+3gQQyq47veMC+J0dbzZ3I8kLGIr6kI8y1xrK4pVFXjHQXlq5Kh0+oIUUPL/DpmljVeIFslVjde9Xt9pgZTZgbUXv3zTIq2gLMW4KC4efYkWpnpmT6TruV6Ym/3AZCinWv7rtKkPhbvlTxhnQRNaWur+BrFWQ1F4YTrod5UMl7KtevXCLqTby5oJ3QmZLNxmGZBoKUnrEWL4Gcf7hK/JYvtPszjPkeUaHW8tPmakmHnpvjm4Pnm/2ackS8Z3Izue2a6Hre7VPjVO35HXSEzwApXoXGfivJ6fXK1Ifd4Uv3aiJ3iwD2u0ACtrQEaorzGJKvEjAWNxYGLsTyCoMvpR3g86EWNtEb8HbWHZl7adhp5iHwbRMJYYifx1j7p3aEg/eMtINVLHzS3+6SRQS1YHyM2jRF6nPl1LnjZSz5Ex+TLyEq9JHgl6kBBOJMg+EACeGMN2m5GRre4kbDa/b6SAslEmVLjAbMeFJGYOBU2QOEu5J7kzyIWilQp830yQrlM7EBM6j7B7ZjPH6ZVNpiZJesWJbvZ/dWTY+nUmUozupybuFjqoJTcQHYPFZRBHcvdhCR93J462aQt030rhoOLd9OQd5XI+gwfp0d8vJameYQ0rTyCXA6Uaf1z7igke6a5mTqt4="
         on:


### PR DESCRIPTION
Mostly when PR are opened with a branch created on upstream (like it's done by dependabot for example).

For example, that PR is created using a branch pushed to upstream and it should only trigger one build.

Also:
- remove cache of `node_modules` to avoid side effect
- update travis config file
