### PR TITLE
Add doc comment for modal hidden button

### DIFF
--- a/src/styl/_components/_modal.styl
+++ b/src/styl/_components/_modal.styl
@@ -11,6 +11,7 @@
 // .modal-window-small - modal width 440px
 // .modal-window-medium - modal width 600px
 // .modal-window-closeOutside - close button outside modal body
+// .modal-window-closeHidden - close button hidden
 // .modal-window-fixedHeight - modal with a fixed height at 70vh and an inner scroll
 //
 // Markup: modal.twig


### PR DESCRIPTION
# What did you fix or what feature did you add?
I add the doc comment for modal hidden button style

Github issue: https://zube.io/20minutes/vega/c/13680

![image](https://user-images.githubusercontent.com/19707072/88927543-deda2180-d277-11ea-9862-b026b34e354d.png)
