### PR TITLE
Firefox pager go in negative fix

### DIFF
--- a/src/js/pager.js
+++ b/src/js/pager.js
@@ -45,6 +45,7 @@ function Pager(cfg) {
 
   this.btnPrev = this.pager.querySelector('.pager-prev')
   this.btnNext = this.pager.querySelector('.pager-next')
+  this.btnPrev.disabled = true
 
   // event handlers
   this.btnPrev.addEventListener('click', this.paginateEventHandler.bind(this))


### PR DESCRIPTION
# What did you fix or what feature did you add?
I fixed the pager that in negative on firefox when you went on the second page and you refreshed the page.

Add Screenshots before/after if it’s relevant

# Related story / issue:
Github issue: https://zube.io/20minutes/vega/c/14357

Don’t forget to: mark if your Pull Request is Ready For Review, Work In Progress.
