### PR TITLE
Try to fix issue on chrome with hyphens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "license": "MIT",
   "dependencies": {
     "@accede-web/tablist": "^2.0.1",

--- a/src/styl/_base/_typography.styl
+++ b/src/styl/_base/_typography.styl
@@ -133,7 +133,7 @@ samp
 div
 p
     word-wrap break-word
-    hyphens none
+    hyphens manual
 
 // (1) we keep spaces and carriage return as far as possible
 code


### PR DESCRIPTION
# What did you fix or what feature did you add?

I try to fix hyphens issue on some browsers. It seems to add useless line breaks inside paragraphs using links.

Note: it's just a test as we don't know exactly why this behavior is not consistant through browsers.