### PR TITLE
Reconfigure git to use HTTP authentication in workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
 
       - name: Use node ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
 
       - name: Use node ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "5.4.0",
+      "version": "5.5.0",
       "license": "MIT",
       "dependencies": {
         "@accede-web/tablist": "^2.0.1",


### PR DESCRIPTION
It was already done for test, but needed to be applied to GitHub Pages & NPM publish workflow.

The main idea is to bypass the error generated when installing deps:

```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/ryuran/postcss-custom-properties.git
npm ERR!
npm ERR! Warning: Permanently added the RSA host key for IP address '140.82.121.3' to the list of known hosts.
npm ERR! git@github.com: Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
npm ERR!
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.
npm ERR!
npm ERR! exited with error code: 128
```

- https://github.com/20minutes/colette/runs/2501720190?check_suite_focus=true
- https://github.com/20minutes/colette/runs/2501560758
