### PR TITLE
Fix webpack resources import

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,10 +71,6 @@ module.exports = async (env) => {
             },
           ],
         },
-        {
-          test: /\.(eot|ttf|woff2?)$/,
-          use: ['file-loader'],
-        },
       ],
     },
     resolve: {
@@ -100,7 +96,15 @@ module.exports = async (env) => {
         patterns: [
           {
             from: 'demo-img/',
-            to: 'dist/img',
+            to: './img',
+          },
+          {
+            from: 'src/fonts/',
+            to: './fonts',
+          },
+          {
+            from: 'favicon.ico',
+            to: './',
           },
         ],
       })


### PR DESCRIPTION
# What did you fix or what feature did you add?
There were some regressions since the upgrade to Webpack V5: resources like img used for demo, fonts, favicon were on 404. 
They weren't simply not imported.

I also removed the call to `file-loader` since it became obsolete


Before:
![image](https://user-images.githubusercontent.com/35305886/143222709-fe0aac32-3492-4cfe-b277-2c15443b3d0b.png)
![image](https://user-images.githubusercontent.com/35305886/143222844-f0d151ff-7bc6-4f0a-bcd4-abe78481d987.png)



After:
![image](https://user-images.githubusercontent.com/35305886/143222761-50fb78cc-7065-43c1-b2b9-c466d100ceb1.png)
![image](https://user-images.githubusercontent.com/35305886/143222877-6aa43fc4-afe0-47fc-88c0-fd48225af6dc.png)