### PR TITLE
Fix resources import on production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,16 +82,6 @@ module.exports = async (env) => {
       new MiniCssExtractPlugin({
         filename: '[name].min.css',
       }),
-    ],
-  }
-
-  if (!env || env.NODE_ENV !== 'dist') {
-    // kss
-    kssConfig.svgSprite = await getSvgSprite()
-    config.plugins.push(new KssWebpackPlugin(kssConfig))
-
-    // assets for kss demo
-    config.plugins.push(
       new CopyPlugin({
         patterns: [
           {
@@ -107,8 +97,14 @@ module.exports = async (env) => {
             to: './',
           },
         ],
-      })
-    )
+      }),
+    ],
+  }
+
+  if (!env || env.NODE_ENV !== 'dist') {
+    // kss
+    kssConfig.svgSprite = await getSvgSprite()
+    config.plugins.push(new KssWebpackPlugin(kssConfig))
   }
 
   return config


### PR DESCRIPTION
# What did you fix or what feature did you add?
This relates to the previous #1181
While the issue of resources not imported is fixed on dev environment, it still persist on production.

So I moved the CopyPlugin from the env. dev.
This should solve it