### PR TITLE
Fix accordion font-size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colette",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "colette",
-      "version": "5.6.0",
+      "version": "5.6.1",
       "license": "MIT",
       "dependencies": {
         "@accede-web/accordion": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "license": "MIT",
   "dependencies": {
     "@accede-web/accordion": "^1.1.0",

--- a/src/styl/_components/_accordion.styl
+++ b/src/styl/_components/_accordion.styl
@@ -11,6 +11,7 @@
 
     &-subhead
         display flex
+        font-size _rem(17px)
 
         &-button
             _p(2)
@@ -27,7 +28,6 @@
             border-radius $radius
             width 100%
             text-align left
-            font-size _rem(17px)
             font-weight bold
             color var(--color-base)
 

--- a/src/styl/_components/accordion.twig
+++ b/src/styl/_components/accordion.twig
@@ -4,6 +4,8 @@
     </h3>
     <div id="panel1" aria-labelledby="tab1" class="accordion-body">
         <p>Exemple de paragraphe</p>
+        <h3 class="accordion-subhead mt1 mb1">Exemple de sous-entête</h3>
+        <p>Exemple de paragraphe</p>
     </div>
     <h3 class="accordion-subhead">
         <button id="tab2" class="accordion-subhead-button" aria-controls="panel2" >Entête n<sup>o</sup> 2</button>


### PR DESCRIPTION
# What did you fix or what feature did you add?
The font size of the title  was applied on the button and not the title.
This can be problemtic if we want to add some subtitles in the panels

![image](https://user-images.githubusercontent.com/35305886/143612766-005d544a-7f93-4eff-b246-356f1340138f.png)

