### PR TITLE
Fix/accordion title padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colette",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "colette",
-      "version": "5.6.1",
+      "version": "5.6.2",
       "license": "MIT",
       "dependencies": {
         "@accede-web/accordion": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "license": "MIT",
   "dependencies": {
     "@accede-web/accordion": "^1.1.0",

--- a/src/styl/_components/_accordion.styl
+++ b/src/styl/_components/_accordion.styl
@@ -14,7 +14,7 @@
         font-size _rem(17px)
 
         &-button
-            _p(2)
+            _p(2 4 2 2)
             _mb(1)
             _fontload($fontstack-secondary)
             background-color var(--color-bg-secondary)


### PR DESCRIPTION
# What did you fix or what feature did you add?

When the title is too long, it overlaps with the arrow (especially on mobile). Increasing its right padding will prevent that

Before:
![image](https://user-images.githubusercontent.com/35305886/144063016-b0e2e6ae-64c9-4fe5-9e5f-a913207569de.png)

![image](https://user-images.githubusercontent.com/35305886/144063067-008b8f6e-9339-4f09-9c70-2e2c9e5ca16d.png)

