### PR TITLE
New styl for breaking news component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "license": "MIT",
   "dependencies": {
     "@accede-web/accordion": "^1.1.0",

--- a/src/styl/_components/_breakingnews.styl
+++ b/src/styl/_components/_breakingnews.styl
@@ -6,60 +6,51 @@
 // Markup: breakingnews.twig
 //
 // Styleguide: Components.BreakingNews
-/:root
-/[data-theme=light]
-/[data-theme] [data-theme=light]
-    --breakingnews-title-color: var(--color-highlight)
-
-/[data-theme=dark]
-/[data-theme] [data-theme=dark]
-    --breakingnews-title-color: var(--color-highlight-foreground)
 
 .breakingnews
+    _p(1 0)
     _fontload($fontstack-secondary)
-    display flex
-    background var(--color-bg-primary)
+    background var(--color-highlight)
+    color var(--color-highlight-foreground)
     font-weight bold
-    flex-wrap nowrap
-    align-items stretch
-    justify-content stretch
     border 0 // no border even it’s box
+    display flex
+    justify-content space-between
+    align-items center
 
-    &-label
-    &-title
-    &-cta
+    &-link
         display flex
         align-items center
-        line-height 1.3em
 
-    &-label
-        _p(1)
-        text-transform uppercase
-        background var(--color-highlight)
-        color var(--color-highlight-foreground)
-        font-size .75em
-
-        @media $breakpoints.md
-            font-size 1em
-
-    &-title
-        _p(.5 1)
-        _fontload($fontstack-secondary)
-        flex-grow 1
-        min-height _rem(62px)
-        color var(--breakingnews-title-color)
-        font-size 1em
-        font-weight bold
-
-        @media $breakpoints.sm
-            font-size 1.375em
-
-    &-cta
-        _p(1)
-        display none
-        color var(--color-base)
-        font-weight bold
-        font-size .875em
-
-        @media $breakpoints.md
+        &-label
+        &-title
             display flex
+            align-items center
+            line-height 1.3em
+            padding 0 0.75rem
+
+        &-label
+            position relative
+            text-transform uppercase
+            font-size .75em
+
+            &:after
+                content ""
+                width 1px
+                height 100%
+                background-color var(--color-highlight-foreground)
+                position absolute
+                right 0
+
+            @media $breakpoints.md
+                font-size 1em
+
+        &-title
+            font-size _rem(16px)
+            font-weight bold
+
+    &-close
+        _p(0 2)
+        transform rotate(45deg)
+        background transparent
+        color $color-white

--- a/src/styl/_components/breakingnews.twig
+++ b/src/styl/_components/breakingnews.twig
@@ -1,5 +1,9 @@
-<a href="#" class="breakingnews box">
-    <span class="breakingnews-label">Breaking News</span>
-    <strong class="breakingnews-title">Important title of a new important article</strong>
-    <span class="breakingnews-cta">Read this article</span>
-</a>
+<section class="breakingnews" >
+    <a class="breakingnews-link" href="#">
+        <span class="breakingnews-link-label">
+            <svg width="30" height="30"><use xlink:href="#symbol-flash"></use></svg>Breaking News
+        </span>
+        <strong class="breakingnews-link-title">Important title of a new important article</strong>
+    </a>
+    <button class="breakingnews-close"><svg width="10" height="10"><use xlink:href="#symbol-cross"></use></svg></button>
+</section>

--- a/src/svg/flash.svg
+++ b/src/svg/flash.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"  xml:space="preserve">
+  <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="16" y1="1.62" x2="16" y2="33.62" gradientTransform="matrix(1 0 0 -1 0 33.62)">
+    <stop offset="0" style="stop-color:#eea701"/>
+    <stop offset=".5" style="stop-color:#f4ba00"/>
+    <stop offset="1" style="stop-color:#fedc00"/>
+  </linearGradient>
+  <path d="M16.2 0h6.2L15 13.3h5.1L9.6 32l5.1-15.6-5.1-.1L16.2 0z" style="fill:url(#a)"/>
+</svg>


### PR DESCRIPTION
# What did you fix or what feature did you add?
I changed styl of the breaking news component for the new integration in vega project.We want to show it at the bottom of the page and on top of the toolbar when both are present.
i remove all styl for dark mode cause he never change.

Add Screenshots before/after if it’s relevant

# Related story / issue:
Github issue: #11092 https://zube.io/20minutes/vega/c/17805

before : 
![Capture d’écran 2021-12-15 à 11 43 25](https://user-images.githubusercontent.com/39522234/146172677-c8ddc730-38ef-4258-a4db-b58ab304b519.png)
![Capture d’écran 2021-12-15 à 11 43 09](https://user-images.githubusercontent.com/39522234/146172683-02508cb9-d5ac-48a3-b934-4c36bcf5ba3b.png)

After : 
![Capture d’écran 2021-12-15 à 11 31 42](https://user-images.githubusercontent.com/39522234/146172709-a7106d6f-0b4d-4f66-8a48-e765b330b3da.png)
![Capture d’écran 2021-12-15 à 11 31 35](https://user-images.githubusercontent.com/39522234/146172711-d8bb8752-9960-4066-bd06-aa2702fe20e0.png)

