### PR TITLE
Rename class of breakingnews

### DIFF
--- a/src/styl/_components/_breakingnews.styl
+++ b/src/styl/_components/_breakingnews.styl
@@ -8,49 +8,51 @@
 // Styleguide: Components.BreakingNews
 
 .breakingnews
-    _p(1 0)
-    _fontload($fontstack-secondary)
-    background var(--color-highlight)
-    color var(--color-highlight-foreground)
-    font-weight bold
-    border 0 // no border even it’s box
-    display flex
-    justify-content space-between
-    align-items center
 
-    &-link
+    &-content
+        _p(1 0)
+        _fontload($fontstack-secondary)
+        background var(--color-highlight)
+        color var(--color-highlight-foreground)
+        font-weight bold
+        border 0 // no border even it’s box
         display flex
+        justify-content space-between
         align-items center
 
-        &-label
-        &-title
+        &-link
             display flex
             align-items center
-            line-height 1.3em
-            padding 0 0.75rem
 
-        &-label
-            position relative
-            text-transform uppercase
-            font-size .75em
+            &-label
+            &-title
+                display flex
+                align-items center
+                line-height 1.3em
+                padding 0 0.75rem
 
-            &:after
-                content ""
-                width 1px
-                height 100%
-                background-color var(--color-highlight-foreground)
-                position absolute
-                right 0
+            &-label
+                position relative
+                text-transform uppercase
+                font-size .75em
 
-            @media $breakpoints.md
-                font-size 1em
+                &:after
+                    content ""
+                    width 1px
+                    height 100%
+                    background-color var(--color-highlight-foreground)
+                    position absolute
+                    right 0
 
-        &-title
-            font-size _rem(16px)
-            font-weight bold
+                @media $breakpoints.md
+                    font-size 1em
 
-    &-close
-        _p(0 2)
-        transform rotate(45deg)
-        background transparent
-        color $color-white
+            &-title
+                font-size _rem(16px)
+                font-weight bold
+
+        &-close
+            _p(0 2)
+            transform rotate(45deg)
+            background transparent
+            color $color-white

--- a/src/styl/_components/breakingnews.twig
+++ b/src/styl/_components/breakingnews.twig
@@ -1,9 +1,9 @@
-<section class="breakingnews" >
-    <a class="breakingnews-link" href="#">
-        <span class="breakingnews-link-label">
+<section class="breakingnews-content" >
+    <a class="breakingnews-content-link" href="#">
+        <span class="breakingnews-content-link-label">
             <svg width="30" height="30"><use xlink:href="#symbol-flash"></use></svg>Breaking News
         </span>
-        <strong class="breakingnews-link-title">Important title of a new important article</strong>
+        <strong class="breakingnews-content-link-title">Important title of a new important article</strong>
     </a>
-    <button class="breakingnews-close"><svg width="10" height="10"><use xlink:href="#symbol-cross"></use></svg></button>
+    <button class="breakingnews-content-close"><svg width="10" height="10"><use xlink:href="#symbol-cross"></use></svg></button>
 </section>


### PR DESCRIPTION
# What did you fix or what feature did you add?
I fixed the name of class to alright with the  SMACS method

Add Screenshots before/after if it’s relevant

# Related story / issue:
Github issue: #11092 https://zube.io/20minutes/vega/c/17805

