### PR TITLE
Change Preview class for catchline 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "colette",
-  "version": "5.6.3",
+  "version": "5.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "5.6.3",
+      "name": "colette",
+      "version": "5.6.4",
       "license": "MIT",
       "dependencies": {
         "@accede-web/accordion": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.6.3",
+  "version": "5.6.4",
   "license": "MIT",
   "dependencies": {
     "@accede-web/accordion": "^1.1.0",

--- a/src/styl/_components/_preview.styl
+++ b/src/styl/_components/_preview.styl
@@ -47,10 +47,6 @@
             @media $breakpoints.sm
                 font-size .9em
 
-        &-catchline
-            background-color var(--color-native)
-            color var(--color-native-foreground)
-
     &-cover // when preview is cover
         .media
             img


### PR DESCRIPTION
# What did you fix or what feature did you add?
I fixed the styl of preview class, for catchline default styl the goal is to be able to meet the need for the catchline and therefore be able to change the basic state which was with a yellow background

Add Screenshots before/after if it’s relevant

![Capture d’écran 2022-01-11 à 17 03 29](https://user-images.githubusercontent.com/39522234/148977950-4e3f3892-e253-4945-9c7b-20091ba43a17.png)
![Capture d’écran 2022-01-11 à 17 03 23](https://user-images.githubusercontent.com/39522234/148977958-0ff1dc78-5e26-49d0-90bc-b9b1ec905024.png)

# Related story / issue:
Github issue: #11190 https://zube.io/20minutes/vega/c/18103


