### PR TITLE
Revert breaking news elements styl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colette",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "colette",
-      "version": "5.6.4",
+      "version": "5.6.5",
       "license": "MIT",
       "dependencies": {
         "@accede-web/accordion": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colette",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "license": "MIT",
   "dependencies": {
     "@accede-web/accordion": "^1.1.0",

--- a/src/styl/_components/_breakingnews.styl
+++ b/src/styl/_components/_breakingnews.styl
@@ -6,51 +6,60 @@
 // Markup: breakingnews.twig
 //
 // Styleguide: Components.BreakingNews
+/:root
+/[data-theme=light]
+/[data-theme] [data-theme=light]
+    --breakingnews-title-color: var(--color-highlight)
+
+/[data-theme=dark]
+/[data-theme] [data-theme=dark]
+    --breakingnews-title-color: var(--color-highlight-foreground)
 
 .breakingnews
-    _p(1 0)
     _fontload($fontstack-secondary)
-    background var(--color-highlight)
-    color var(--color-highlight-foreground)
-    font-weight bold
-    border 0 // no border even it’s box
     display flex
-    justify-content space-between
-    align-items center
+    background var(--color-bg-primary)
+    font-weight bold
+    flex-wrap nowrap
+    align-items stretch
+    justify-content stretch
+    border 0 // no border even it’s box
 
-    &-link
+    &-label
+    &-title
+    &-cta
         display flex
         align-items center
+        line-height 1.3em
 
-        &-label
-        &-title
+    &-label
+        _p(1)
+        text-transform uppercase
+        background var(--color-highlight)
+        color var(--color-highlight-foreground)
+        font-size .75em
+
+        @media $breakpoints.md
+            font-size 1em
+
+    &-title
+        _p(.5 1)
+        _fontload($fontstack-secondary)
+        flex-grow 1
+        min-height _rem(62px)
+        color var(--breakingnews-title-color)
+        font-size 1em
+        font-weight bold
+
+        @media $breakpoints.sm
+            font-size 1.375em
+
+    &-cta
+        _p(1)
+        display none
+        color var(--color-base)
+        font-weight bold
+        font-size .875em
+
+        @media $breakpoints.md
             display flex
-            align-items center
-            line-height 1.3em
-            padding 0 0.75rem
-
-        &-label
-            position relative
-            text-transform uppercase
-            font-size .75em
-
-            &:after
-                content ""
-                width 1px
-                height 100%
-                background-color var(--color-highlight-foreground)
-                position absolute
-                right 0
-
-            @media $breakpoints.md
-                font-size 1em
-
-        &-title
-            font-size _rem(16px)
-            font-weight bold
-
-    &-close
-        _p(0 2)
-        transform rotate(45deg)
-        background transparent
-        color $color-white

--- a/src/styl/_components/breakingnews.twig
+++ b/src/styl/_components/breakingnews.twig
@@ -1,9 +1,5 @@
-<section class="breakingnews" >
-    <a class="breakingnews-link" href="#">
-        <span class="breakingnews-link-label">
-            <svg width="30" height="30"><use xlink:href="#symbol-flash"></use></svg>Breaking News
-        </span>
-        <strong class="breakingnews-link-title">Important title of a new important article</strong>
-    </a>
-    <button class="breakingnews-close"><svg width="10" height="10"><use xlink:href="#symbol-cross"></use></svg></button>
-</section>
+<a href="#" class="breakingnews box">
+    <span class="breakingnews-label">Breaking News</span>
+    <strong class="breakingnews-title">Important title of a new important article</strong>
+    <span class="breakingnews-cta">Read this article</span>
+</a>


### PR DESCRIPTION
# What did you fix or what feature did you add?
I reverted styl of breakingnews banner cause is not ready to be deployed in master.
for me is the better solution to make a something clean in the workflow

Add Screenshots before/after if it’s relevant

# Related story / issue:
Github issue: #11126 


