### PR TITLE
Add ellipsis style for mobile

### DIFF
--- a/src/styl/_components/_breakingnews.styl
+++ b/src/styl/_components/_breakingnews.styl
@@ -48,6 +48,12 @@
         &-title
             font-size _rem(16px)
             font-weight bold
+            text-overflow ellipsis
+            overflow hidden
+            display -webkit-box !important
+            -webkit-line-clamp 3
+            -webkit-box-orient vertical
+            white-space normal
 
     &-close
         _p(0 2)

--- a/src/styl/_components/_preview.styl
+++ b/src/styl/_components/_preview.styl
@@ -190,8 +190,12 @@
             &-title
                 font-size .9em
                 font-weight 600
-                height _rem(65px)
                 overflow hidden
+                text-overflow ellipsis
+                display -webkit-box !important
+                -webkit-line-clamp 4
+                -webkit-box-orient vertical
+                white-space normal
 
             &-summary
                 display none


### PR DESCRIPTION
# What did you fix or what feature did you add?
I added styl for breaking-news and preview-reduc when text is too long, in the breaking-news banner after 3 lines and 4 for title in preview-reduc who's used in horizontal slider.

Add Screenshots before/after if it’s relevant

# Related story / issue:

![Capture d’écran 2022-02-16 à 10 17 38](https://user-images.githubusercontent.com/39522234/154240465-aa69fc6f-7d1a-4fba-a03a-f87bc82ed0ef.png)

photo not contractual just to show the difference :

![Capture d’écran 2022-02-16 à 11 10 08](https://user-images.githubusercontent.com/39522234/154243160-3203d435-7064-452b-a3c2-e740e08cc9cd.png)

